### PR TITLE
Add documentation for the '...' method argument

### DIFF
--- a/R/clean_baseline.r
+++ b/R/clean_baseline.r
@@ -16,6 +16,7 @@
 ##' @param x a syndromic (\code{syndromicD} or \code{syndromicW}) object, 
 ##' which must have at least 
 ##' the slot of observed data and a data frame in the slot dates.
+##' @param ... Additional arguments to the method.
 ##' @param syndromes an optional parameter, if not specified, all
 ##' columns in the slot observed of the syndromic object
 ##' will be used. The user can choose to restrict the analyses to 

--- a/R/clean_baseline_perc.r
+++ b/R/clean_baseline_perc.r
@@ -19,6 +19,7 @@
 ##' @param x a syndromic (\code{syndromicD} or \code{syndromicW}) object, 
 ##' which must have at least 
 ##' the slot of observed data and a data frame in the slot dates.
+##' @param ... Additional arguments to the method.
 ##' @param syndromes an optional parameter, if not specified, all
 ##' columns in the slot observed of the syndromic object
 ##' will be used. The user can choose to restriict the analyses to 

--- a/R/cusum.r
+++ b/R/cusum.r
@@ -59,6 +59,7 @@
 ##' regression is going to be used, the slot dates must contain
 ##' a data.frame containing at least the columns for the regression 
 ##' variables chosen to be used (year, dow, month).
+##' @param ... Additional arguments to the method.
 ##' @param syndromes an optional parameter, if not specified, all
 ##' columns in the slot observed of the \code{syndromic} object
 ##' will be used. The user can choose to restrict the analyses to 

--- a/R/ewma.r
+++ b/R/ewma.r
@@ -58,6 +58,7 @@
 ##' regression is going to be used, the slot dates must contain
 ##' a data.frame containing at least the columns for the regression 
 ##' variables chosen to be used.
+##' @param ... Additional arguments to the method.
 ##' @param syndromes an optional parameter, if not specified, all
 ##' columns in the slot observed of the syndromic object
 ##' will be used. The user can choose to restrict the analyses to 

--- a/R/holt_winters.r
+++ b/R/holt_winters.r
@@ -42,6 +42,7 @@
 ##' variable  year in the slot dates. If the slot baseline is not 
 ##' available, then the data in the slot observed will be copied into
 ##' the baseline slot.
+##' @param ... Additional arguments to the method.
 ##' @param syndromes an optional parameter, if not specified, all
 ##' columns in the slot observed of the \code{syndromic} object
 ##' will be used. The user can choose to restrict the analyses to 

--- a/R/plot_syndromic.r
+++ b/R/plot_syndromic.r
@@ -11,6 +11,7 @@
 ##' 
 ##' 
 ##' @param x a syndromic (\code{syndromicD} or \code{syndromicW}) object.
+##' @param ... Additional arguments to the method.
 ##' @param syndromes an optional parameter, if not specified, all
 ##' columns in the slot observed (or baseline of the
 ##'  \code{syndromic} object

--- a/R/pre_process_glm.r
+++ b/R/pre_process_glm.r
@@ -18,6 +18,7 @@
 ##' @param x a syndromic (\code{syndromicD} or \code{syndromicW})
 ##'  object, which must have at least 
 ##' the slot of observed data and a data frame in the slot dates.
+##' @param ... Additional arguments to the method.
 ##' @param slot the slot in the \code{syndromic} object to be processed,
 ##' by default, "observed", but this argument can be used to
 ##' change it to "baseline"

--- a/R/retro_summary.r
+++ b/R/retro_summary.r
@@ -22,6 +22,7 @@
 ##' @param x a syndromic (\code{syndromicD} or \code{syndromicW}) object, 
 ##' from where dates and observed
 ##' data will be extracted.
+##' @param ... Additional arguments to the method.
 ##' @param object.name a name for the title in the html file, by default
 ##' "my.syndromic".
 ##' @param file.name a name for the rmd/html file to be created with

--- a/R/shew.r
+++ b/R/shew.r
@@ -59,6 +59,7 @@
 ##' regression is going to be used, the slot dates must contain
 ##' a data frame containing at least the columns for the regression 
 ##' variables chosen to be used.
+##' @param ... Additional arguments to the method.
 ##' @param syndromes an optional parameter, if not specified, all
 ##' columns in the slot observed of the syndromic object
 ##' will be used. The user can choose to restrict the analyses to 

--- a/R/syndromic_alarm.r
+++ b/R/syndromic_alarm.r
@@ -12,6 +12,7 @@
 ##' 
 ##' 
 ##' @param x a syndromic (\code{syndromicD} or \code{syndromicW}) object.
+##' @param ... Additional arguments to the method.
 ##' @param pdf.report default is TRUE, that is, a pdf report will be generated. 
 ##' @param email.alarm.to email recipient(s) for when an alarm is detected. If
 ##' a pdf report has been generated, it will be attached to the email. See examples

--- a/R/syndromic_page.r
+++ b/R/syndromic_page.r
@@ -11,6 +11,7 @@
 ##' 
 ##' @param x a syndromic (\code{syndromicD} 
 ##' or \code{syndromicW}) object.
+##' @param ... Additional arguments to the method.
 ##' @param tpoints.display This is used to choose how many days of alarms to display. The
 ##' normal for daily data (syndromic object provided is form the class \code{syndromicD} )
 ##' is to show the entire last week (so 7 or 5 days, depending on whether weekends are

--- a/R/update_syndromicD.r
+++ b/R/update_syndromicD.r
@@ -8,6 +8,7 @@
 ##' @docType methods
 ##' @param x the \code{syndromicD} object to be updated (if one does not already exist,
 ##' please use "raw_to_syndromicD" or "syndromicD")
+##' @param ... Additional arguments to the method.
 ##' @param id indicates a variable (or multiple variables) which should
 ##' be used to identify unique events in the data. It can be provided as an R
 ##' vector (p.e. mydata$myid), as the name of a Data Frame column

--- a/man/clean_baseline.Rd
+++ b/man/clean_baseline.Rd
@@ -18,6 +18,8 @@ clean_baseline(x, ...)
 which must have at least
 the slot of observed data and a data frame in the slot dates.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{syndromes}{an optional parameter, if not specified, all
 columns in the slot observed of the syndromic object
 will be used. The user can choose to restrict the analyses to

--- a/man/clean_baseline_perc.Rd
+++ b/man/clean_baseline_perc.Rd
@@ -15,6 +15,8 @@ clean_baseline_perc(x, ...)
 which must have at least
 the slot of observed data and a data frame in the slot dates.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{syndromes}{an optional parameter, if not specified, all
 columns in the slot observed of the syndromic object
 will be used. The user can choose to restriict the analyses to

--- a/man/cusum_synd.Rd
+++ b/man/cusum_synd.Rd
@@ -20,6 +20,8 @@ regression is going to be used, the slot dates must contain
 a data.frame containing at least the columns for the regression
 variables chosen to be used (year, dow, month).}
 
+\item{...}{Additional arguments to the method.}
+
 \item{syndromes}{an optional parameter, if not specified, all
 columns in the slot observed of the \code{syndromic} object
 will be used. The user can choose to restrict the analyses to

--- a/man/ewma_synd.Rd
+++ b/man/ewma_synd.Rd
@@ -20,6 +20,8 @@ regression is going to be used, the slot dates must contain
 a data.frame containing at least the columns for the regression
 variables chosen to be used.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{syndromes}{an optional parameter, if not specified, all
 columns in the slot observed of the syndromic object
 will be used. The user can choose to restrict the analyses to

--- a/man/holt_winters_synd.Rd
+++ b/man/holt_winters_synd.Rd
@@ -21,6 +21,8 @@ variable  year in the slot dates. If the slot baseline is not
 available, then the data in the slot observed will be copied into
 the baseline slot.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{syndromes}{an optional parameter, if not specified, all
 columns in the slot observed of the \code{syndromic} object
 will be used. The user can choose to restrict the analyses to

--- a/man/plot_syndromic.Rd
+++ b/man/plot_syndromic.Rd
@@ -13,6 +13,8 @@ plot_syndromic(x, ...)
 \arguments{
 \item{x}{a syndromic (\code{syndromicD} or \code{syndromicW}) object.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{syndromes}{an optional parameter, if not specified, all
 columns in the slot observed (or baseline of the
  \code{syndromic} object

--- a/man/pre_process_glm.Rd
+++ b/man/pre_process_glm.Rd
@@ -16,6 +16,8 @@ pre_process_glm(x, ...)
  object, which must have at least
 the slot of observed data and a data frame in the slot dates.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{slot}{the slot in the \code{syndromic} object to be processed,
 by default, "observed", but this argument can be used to
 change it to "baseline"}

--- a/man/retro_summary.Rd
+++ b/man/retro_summary.Rd
@@ -15,6 +15,8 @@ retro_summary(x, ...)
 from where dates and observed
 data will be extracted.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{object.name}{a name for the title in the html file, by default
 "my.syndromic".}
 

--- a/man/shew_synd.Rd
+++ b/man/shew_synd.Rd
@@ -20,6 +20,8 @@ regression is going to be used, the slot dates must contain
 a data frame containing at least the columns for the regression
 variables chosen to be used.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{syndromes}{an optional parameter, if not specified, all
 columns in the slot observed of the syndromic object
 will be used. The user can choose to restrict the analyses to

--- a/man/syndromic_alarm.Rd
+++ b/man/syndromic_alarm.Rd
@@ -18,6 +18,8 @@ syndromic_alarm(x, ...)
 \arguments{
 \item{x}{a syndromic (\code{syndromicD} or \code{syndromicW}) object.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{pdf.report}{default is TRUE, that is, a pdf report will be generated.}
 
 \item{email.alarm.to}{email recipient(s) for when an alarm is detected. If

--- a/man/syndromic_page.Rd
+++ b/man/syndromic_page.Rd
@@ -19,6 +19,8 @@ syndromic_page(x, ...)
 \item{x}{a syndromic (\code{syndromicD}
 or \code{syndromicW}) object.}
 
+\item{...}{Additional arguments to the method.}
+
 \item{tpoints.display}{This is used to choose how many days of alarms to display. The
 normal for daily data (syndromic object provided is form the class \code{syndromicD} )
 is to show the entire last week (so 7 or 5 days, depending on whether weekends are

--- a/man/update_syndromic.Rd
+++ b/man/update_syndromic.Rd
@@ -15,6 +15,8 @@ update_syndromic(x, ...)
 \item{x}{the \code{syndromicD} object to be updated (if one does not already exist,
 please use "raw_to_syndromicD" or "syndromicD")}
 
+\item{...}{Additional arguments to the method.}
+
 \item{id}{indicates a variable (or multiple variables) which should
 be used to identify unique events in the data. It can be provided as an R
 vector (p.e. mydata$myid), as the name of a Data Frame column


### PR DESCRIPTION
This fixes the `R CMD check` warning of undocumented '...' arguments in the documentation
