### PR TITLE
Add 'Makefile' to '.Rbuildignore'

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,3 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
 ^LICENSE$
+^Makefile$


### PR DESCRIPTION
Fixes the following note from `R CMD check`

```
* checking top-level files ... NOTE
Non-standard file/directory found at top level:
  ‘Makefile’
```
