### PR TITLE
Changed dimnames for alarms, UCL and LCL in cusum, ewma, holt_winters and shew

### DIFF
--- a/R/cusum.r
+++ b/R/cusum.r
@@ -281,8 +281,6 @@ setMethod('cusum_synd',
               } else{
                 dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
               }                  
-              dimnames(y@alarms)[[3]][alarm.dim] <- "CUSUM"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -293,8 +291,8 @@ setMethod('cusum_synd',
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "CUSUM"              
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "CUSUM"              
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -305,8 +303,6 @@ setMethod('cusum_synd',
                 } else{
                   dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
                 }   
-                dimnames(y@UCL)[[3]][alarm.dim] <- "CUSUM"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -317,8 +313,8 @@ setMethod('cusum_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@UCL)[[3]][alarm.dim] <- "CUSUM"              
               }
+              dimnames(y@UCL)[[3]][alarm.dim] <- "CUSUM"              
             }
             
             
@@ -327,8 +323,6 @@ setMethod('cusum_synd',
               if (dim(y@LCL)[1]==0){
                 setLCLD(y)<-array(NA,dim=c(dim(y@observed)[1],dim(y@observed)[2],alarm.dim))
                 dimnames(y@LCL)[[2]] <- dimnames(y@observed)[[2]]
-                dimnames(y@LCL)[[3]][alarm.dim] <- "CUSUM"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -339,8 +333,8 @@ setMethod('cusum_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@LCL)[[3]][alarm.dim] <- "CUSUM"                
               }
+              dimnames(y@LCL)[[3]][alarm.dim] <- "CUSUM"                
             }            
             
             #if Baseline does not exist at all, fill it with NA for the dimensions required 
@@ -636,8 +630,6 @@ setMethod('cusum_synd',
               } else{
                 dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
               }                 
-              dimnames(y@alarms)[[3]][alarm.dim] <- "CUSUM"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -648,8 +640,8 @@ setMethod('cusum_synd',
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "CUSUM"              
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "CUSUM"              
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -660,8 +652,6 @@ setMethod('cusum_synd',
                 } else{
                   dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
                 }   
-                dimnames(y@UCL)[[3]][alarm.dim] <- "CUSUM"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -672,8 +662,8 @@ setMethod('cusum_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@UCL)[[3]][alarm.dim] <- "CUSUM"              
               }
+              dimnames(y@UCL)[[3]][alarm.dim] <- "CUSUM"              
             }
             
             
@@ -682,8 +672,6 @@ setMethod('cusum_synd',
               if (dim(y@LCL)[1]==0){
                 setLCLW(y)<-array(NA,dim=c(dim(y@observed)[1],dim(y@observed)[2],alarm.dim))
                 dimnames(y@LCL)[[2]] <- dimnames(y@observed)[[2]]
-                dimnames(y@LCL)[[3]][alarm.dim] <- "CUSUM"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -694,8 +682,8 @@ setMethod('cusum_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@LCL)[[3]][alarm.dim] <- "CUSUM"                
               }
+              dimnames(y@LCL)[[3]][alarm.dim] <- "CUSUM"                
             }            
             
             #if Baseline does not exist at all, fill it with NA for the dimensions required 

--- a/R/ewma.r
+++ b/R/ewma.r
@@ -283,8 +283,6 @@ y <- x
               } else{
                 dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
               }    
-              dimnames(y@alarms)[[3]][alarm.dim] <- "EWMA"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -295,8 +293,8 @@ y <- x
                               matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                               along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "EWMA"              
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "EWMA"              
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -307,8 +305,6 @@ y <- x
               } else{
                 dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
               }   
-              dimnames(y@UCL)[[3]][alarm.dim] <- "EWMA"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -319,8 +315,8 @@ y <- x
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@UCL)[[3]][alarm.dim] <- "EWMA"              
             }
+            dimnames(y@UCL)[[3]][alarm.dim] <- "EWMA"              
             }
             
             
@@ -329,8 +325,6 @@ y <- x
               if (dim(y@LCL)[1]==0){
                 setLCLD(y)<-array(NA,dim=c(dim(y@observed)[1],dim(y@observed)[2],alarm.dim))
                 dimnames(y@LCL)[[2]] <- dimnames(y@observed)[[2]]
-                dimnames(y@LCL)[[3]][alarm.dim] <- "EWMA"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -341,8 +335,8 @@ y <- x
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@LCL)[[3]][alarm.dim] <- "EWMA"                
               }
+              dimnames(y@LCL)[[3]][alarm.dim] <- "EWMA"                
             }            
             
            #if Baseline does not exist at all, fill it with NA for the dimensions required 
@@ -626,8 +620,6 @@ setMethod('ewma_synd',
               } else{
                 dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
               }                  
-              dimnames(y@alarms)[[3]][alarm.dim] <- "EWMA"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -638,8 +630,8 @@ setMethod('ewma_synd',
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "EWMA"              
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "EWMA"              
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -650,8 +642,6 @@ setMethod('ewma_synd',
                 } else{
                   dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
                 }   
-                dimnames(y@UCL)[[3]][alarm.dim] <- "EWMA"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -662,8 +652,8 @@ setMethod('ewma_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@UCL)[[3]][alarm.dim] <- "EWMA"              
               }
+              dimnames(y@UCL)[[3]][alarm.dim] <- "EWMA"              
             }
             
             
@@ -672,8 +662,6 @@ setMethod('ewma_synd',
               if (dim(y@LCL)[1]==0){
                 setLCLW(y)<-array(NA,dim=c(dim(y@observed)[1],dim(y@observed)[2],alarm.dim))
                 dimnames(y@LCL)[[2]] <- dimnames(y@observed)[[2]]
-                dimnames(y@LCL)[[3]][alarm.dim] <- "EWMA"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -684,8 +672,8 @@ setMethod('ewma_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@LCL)[[3]][alarm.dim] <- "EWMA"                
               }
+              dimnames(y@LCL)[[3]][alarm.dim] <- "EWMA"                
             }            
             
             #if Baseline does not exist at all, fill it with NA for the dimensions required 

--- a/R/holt_winters.r
+++ b/R/holt_winters.r
@@ -236,8 +236,6 @@ setMethod('holt_winters_synd',
                   } else{
                     dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
                   }              
-        
-              dimnames(y@alarms)[[3]][alarm.dim] <- "HoltWinters"
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -248,8 +246,8 @@ setMethod('holt_winters_synd',
                               matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                               along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "HoltWinters"
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "HoltWinters"
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -260,8 +258,6 @@ setMethod('holt_winters_synd',
               } else{
                 dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
               }   
-              
-              dimnames(y@UCL)[[3]][alarm.dim] <- "HoltWinters"
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -272,8 +268,8 @@ setMethod('holt_winters_synd',
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@UCL)[[3]][alarm.dim] <- "HoltWinters"
             }
+            dimnames(y@UCL)[[3]][alarm.dim] <- "HoltWinters"
             }
             
            #if Baseline does not exist at all, fill it with NA for the dimensions required 
@@ -402,7 +398,6 @@ setMethod('holt_winters_synd',
               } else{
                 dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
               }    
-              dimnames(y@alarms)[[3]][alarm.dim] <- "HoltWinters"
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -413,8 +408,8 @@ setMethod('holt_winters_synd',
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "HoltWinters"
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "HoltWinters"
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -425,7 +420,6 @@ setMethod('holt_winters_synd',
                 } else{
                   dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
                 }   
-                dimnames(y@UCL)[[3]][alarm.dim] <- "HoltWinters"
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -436,8 +430,8 @@ setMethod('holt_winters_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@UCL)[[3]][alarm.dim] <- "HoltWinters"
               }
+              dimnames(y@UCL)[[3]][alarm.dim] <- "HoltWinters"
             }
             
             #if Baseline does not exist at all, fill it with NA for the dimensions required 

--- a/R/shew.r
+++ b/R/shew.r
@@ -284,8 +284,6 @@ y <- x
               } else{
                 dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
               }    
-              dimnames(y@alarms)[[3]][alarm.dim] <- "Shewhart"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -296,8 +294,8 @@ y <- x
                               matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                               along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "Shewhart"              
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "Shewhart"              
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -308,8 +306,6 @@ y <- x
               } else{
                 dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
               }   
-              dimnames(y@UCL)[[3]][alarm.dim] <- "Shewhart"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -320,8 +316,8 @@ y <- x
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@UCL)[[3]][alarm.dim] <- "Shewhart"              
             }
+            dimnames(y@UCL)[[3]][alarm.dim] <- "Shewhart"              
             }
             
             
@@ -330,8 +326,6 @@ y <- x
               if (dim(y@LCL)[1]==0){
                 setLCLD(y)<-array(NA,dim=c(dim(y@observed)[1],dim(y@observed)[2],alarm.dim))
                 dimnames(y@LCL)[[2]] <- dimnames(y@observed)[[2]]
-                dimnames(y@LCL)[[3]][alarm.dim] <- "Shewhart"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -342,8 +336,8 @@ y <- x
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@LCL)[[3]][alarm.dim] <- "Shewhart"                
               }
+              dimnames(y@LCL)[[3]][alarm.dim] <- "Shewhart"                
             }            
             
            #if Baseline does not exist at all, fill it with NA for the dimensions required 
@@ -622,8 +616,6 @@ setMethod('shew_synd',
               } else{
                 dimnames(y@alarms)[[2]] <- dimnames(y@observed)[[2]]
               }    
-              dimnames(y@alarms)[[3]][alarm.dim] <- "Shewhart"
-              
             }
             
             #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -634,8 +626,8 @@ setMethod('shew_synd',
                                 matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                 along=3)
               }
-              dimnames(y@alarms)[[3]][alarm.dim] <- "Shewhart"              
             }
+            dimnames(y@alarms)[[3]][alarm.dim] <- "Shewhart"              
             
             #all the same for UCL
             if (UCL!=FALSE){
@@ -646,8 +638,6 @@ setMethod('shew_synd',
                 } else{
                   dimnames(y@UCL)[[2]] <- dimnames(y@observed)[[2]]
                 }   
-                dimnames(y@UCL)[[3]][alarm.dim] <- "Shewhart"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -658,8 +648,8 @@ setMethod('shew_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@UCL)[[3]][alarm.dim] <- "Shewhart"              
               }
+              dimnames(y@UCL)[[3]][alarm.dim] <- "Shewhart"              
             }
             
             
@@ -668,8 +658,6 @@ setMethod('shew_synd',
               if (dim(y@LCL)[1]==0){
                 setLCLW(y)<-array(NA,dim=c(dim(y@observed)[1],dim(y@observed)[2],alarm.dim))
                 dimnames(y@LCL)[[2]] <- dimnames(y@observed)[[2]]
-                dimnames(y@LCL)[[3]][alarm.dim] <- "Shewhart"
-                
               }
               
               #if slot existed, but not up to alarm.dim, add the needed dimensions
@@ -680,8 +668,8 @@ setMethod('shew_synd',
                                matrix(NA,nrow=dim(y@observed)[1],ncol=dim(y@observed)[2]),
                                along=3)
                 }
-                dimnames(y@LCL)[[3]][alarm.dim] <- "Shewhart"                
               }
+              dimnames(y@LCL)[[3]][alarm.dim] <- "Shewhart"                
             }            
             
             #if Baseline does not exist at all, fill it with NA for the dimensions required 


### PR DESCRIPTION
The creation of dimension names is changed so that the name is always created, not only when the dimension is created. This to avoid the situation that you first run for example cusum with standard dimension 4, then run ewma with standard dimension 2. If done so, the dimension name ewma would not have been given to the dimension 2 because the dimension had already been created.
